### PR TITLE
Hyperdrive: Enforce required on all string fields in HyperdriveConfigOrigin

### DIFF
--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -10,8 +10,13 @@ import (
 )
 
 var (
-	ErrMissingHyperdriveConfigID       = errors.New("required hyperdrive config id is missing")
-	ErrMissingHyperdriveConfigName     = errors.New("required hyperdrive config name is missing")
+	ErrMissingHyperdriveConfigID             = errors.New("required hyperdrive config id is missing")
+	ErrMissingHyperdriveConfigName           = errors.New("required hyperdrive config name is missing")
+	ErrMissingHyperdriveConfigOriginDatabase = errors.New("required hyperdrive config origin database is missing")
+	ErrMissingHyperdriveConfigOriginPassword = errors.New("required hyperdrive config origin password is missing")
+	ErrMissingHyperdriveConfigOriginHost     = errors.New("required hyperdrive config origin host is missing")
+	ErrMissingHyperdriveConfigOriginScheme   = errors.New("required hyperdrive config origin scheme is missing")
+	ErrMissingHyperdriveConfigOriginUser     = errors.New("required hyperdrive config origin user is missing")
 )
 
 type HyperdriveConfig struct {
@@ -170,6 +175,26 @@ func (api *API) UpdateHyperdriveConfig(ctx context.Context, rc *ResourceContaine
 
 	if params.HyperdriveID == "" {
 		return HyperdriveConfig{}, ErrMissingHyperdriveConfigID
+	}
+
+	if params.Origin.Database == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginDatabase
+	}
+
+	if params.Origin.Password == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginPassword
+	}
+
+	if params.Origin.Host == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginHost
+	}
+
+	if params.Origin.Scheme == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginScheme
+	}
+
+	if params.Origin.User == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginUser
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/hyperdrive/configs/%s", rc.Identifier, params.HyperdriveID)


### PR DESCRIPTION
All the fields within the Hyperdrive Config Origin object are required. The current API endpoint documentation is incorrect but will be fixed shortly.

## Description

This PR enforces all the fields within the HyperdriveConfigOrigin struct, except for Port since that defaults to a valid value.

## Has your change been tested?

The change passes all the existing test cases in `hyperdrive_test.go`.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
